### PR TITLE
Fix Cloudflare Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=exceptioncoding-net
+          command: pages deploy dist --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          command: pages deploy dist --project-name=exceptioncoding-net


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow to use correct secret for Cloudflare Pages project name
- Changed from `vars.CLOUDFLARE_PAGES_PROJECT_NAME` to `secrets.CLOUDFLARE_PAGES_PROJECT_NAME`
- This resolves the "Must specify a project name" error in deployment

## Test plan
- [x] Verified secret exists in repository
- [x] Workflow should now deploy successfully to Cloudflare Pages