### PR TITLE
Fix flash of light theme on page load

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -39,8 +39,18 @@
     <link rel="stylesheet" href="styles/main.css" />
     <!-- Iconify CDN for SVG icons -->
     <script src="https://code.iconify.design/iconify-icon/1.0.8/iconify-icon.min.js"></script>
+    
+    <!-- Theme loader - runs immediately to prevent flash -->
+    <script>
+      (function() {
+        const theme = localStorage.getItem('theme') || 'dark';
+        if (theme === 'dark') {
+          document.documentElement.classList.add('dark-theme');
+        }
+      })();
+    </script>
   </head>
-  <body>
+  <body class="dark-theme">
     <div class="bg-animation"></div>
     <div class="particles" id="particles"></div>
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -267,6 +267,7 @@ function setThemeSwitch(theme) {
     themeToggle.setAttribute("title", "Switch to dark theme");
   }
 }
+// Initialize theme switch based on current state
 setThemeSwitch(currentTheme);
 themeToggle.addEventListener("click", () => {
   const isDark = document.body.classList.toggle("dark-theme");


### PR DESCRIPTION
## Summary
- Fixed flash of light content before dark theme loads
- Added inline script to apply theme immediately in HTML head
- Set default body class to dark-theme for consistent loading
- Ensures dark mode is default and loads without delay

## Test plan
- [x] Page now loads in dark mode immediately
- [x] No flash of light content with cache disabled
- [x] Theme toggle still works correctly
- [x] Light mode preference is preserved when set